### PR TITLE
feat: add python onehot script

### DIFF
--- a/benches/pandas_onehot.py
+++ b/benches/pandas_onehot.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+def onehot():
+    df = pd.read_csv('data/mushrooms.csv')
+    X = pd.get_dummies(df)
+    return X
+
+
+if __name__ == "__main__":
+    import timeit
+
+    iterations = 1000
+    seconds = timeit.timeit(lambda: onehot(), number=iterations) / iterations
+    print(f"{seconds * 1000} ms")


### PR DESCRIPTION
Adds the Python script for benchmarking the one-hot encoding of pandas. This does not include the loading of the CSV.
Two observations:
- I didn’t include the loading of the CSV in the timings of the Python function, but I do believe that the timings of rust include the loading of the CSV. Perhaps is worth including in the table both timings for Python (with CSV loading and without)  in the blog post
- This is not directly an apple-to-apple comparison since our one-hot function returns a one-column dictionary, and pandas returns a matrix. We could mention that is also one of the strengths of DataFusion the ability to process/work with nested datatypes such as dictionaries (see [this](https://github.com/apache/arrow-datafusion/issues/2326))